### PR TITLE
eg25-autorestart.sh: Run "ofonoctl online" with ofono.

### DIFF
--- a/eg25-autorestart/eg25-autorestart.sh
+++ b/eg25-autorestart/eg25-autorestart.sh
@@ -19,10 +19,12 @@ fi
 
 if [ "$restart_modem" = true ]; then
     modem_manager=()
+    run_ofonoctl=false
     if systemctl -q is-enabled ModemManager; then
         modem_manager+=(ModemManager)
     elif systemctl -q is-enabled ofono; then
         modem_manager+=(ofono)
+        run_ofonoctl=true
     fi
     
     systemctl stop eg25-manager "${modem_manager[@]}"
@@ -71,4 +73,7 @@ if [ "$restart_modem" = true ]; then
     done
 
     systemctl restart "${modem_manager[@]}" eg25-manager
+    if [ "$run_ofonoctl" = true ]; then
+        ofonoctl online
+    fi
 fi


### PR DESCRIPTION
After testing the script on yet another modem disappearance, I found that restarting ofono is not enough to make ofono bring the modem back online (or even power it up), but instead, running "ofonoctl online" explicitly is required.