### PR TITLE
eg25-autorestart: Simplify control flow

### DIFF
--- a/eg25-autorestart/eg25-autorestart.sh
+++ b/eg25-autorestart/eg25-autorestart.sh
@@ -27,60 +27,57 @@ fi
 
 # Either the prefix path did not exist, or no complete set of symlinks
 # could be found under any device name; restart modem.
-restart_modem=true
 
-if [ "$restart_modem" = true ]; then
-    modem_manager=()
-    if systemctl -q is-enabled ModemManager; then
-        modem_manager+=(ModemManager)
-    elif systemctl -q is-enabled ofono; then
-        modem_manager+=(ofono)
-    fi
-    
-    systemctl stop eg25-manager "${modem_manager[@]}"
-    sleep 2
-    
-    # The following is modified work from Dreemurrs Embedded Labs / DanctNIX Community, Copyright (C) 2020.
-    # The original work is available at:
-    # https://github.com/dreemurrs-embedded/Pine64-Arch/blob/1f587391b4ac2e8d72c8b69cf2283a3310e14bb3/PKGBUILDS/pine64/danctnix-eg25-misc/eg25_power.sh
-    
-    # GPIO35 is PWRKEY
-    # GPIO68 is RESET_N
-    # GPIO232 is W_DISABLE
-
-    for i in 35 68 232
-    do
-        [ -e /sys/class/gpio/gpio$i ] && continue
-        echo $i > /sys/class/gpio/export || exit 1
-        echo out > /sys/class/gpio/gpio$i/direction || exit 1
-    done
-
-    echo 1 > /sys/class/gpio/gpio68/value
-    echo 1 > /sys/class/gpio/gpio232/value
-
-    echo 1 > /sys/class/gpio/gpio35/value && sleep 2 && echo 0 > /sys/class/gpio/gpio35/value
-
-    if grep -q 1.1 /proc/device-tree/model
-    then
-        # Intentional delay on Braveheart
-        # As modem gets corrupted very easily on that model.
-        sleep 30
-    else
-        sleep 2
-    fi
-
-    echo 0 > /sys/class/gpio/gpio68/value || exit 1
-    echo 0 > /sys/class/gpio/gpio232/value || exit 1
-
-    ( echo 1 > /sys/class/gpio/gpio35/value && sleep 2 && echo 0 > /sys/class/gpio/gpio35/value ) || exit 1
-    
-    sleep 2
-
-    for i in 35 68 232
-    do
-            [ ! -e /sys/class/gpio/gpio$i ] && continue
-            echo $i > /sys/class/gpio/unexport || exit 1
-    done
-
-    systemctl restart "${modem_manager[@]}" eg25-manager
+modem_manager=()
+if systemctl -q is-enabled ModemManager; then
+    modem_manager+=(ModemManager)
+elif systemctl -q is-enabled ofono; then
+    modem_manager+=(ofono)
 fi
+
+systemctl stop eg25-manager "${modem_manager[@]}"
+sleep 2
+
+# The following is modified work from Dreemurrs Embedded Labs / DanctNIX Community, Copyright (C) 2020.
+# The original work is available at:
+# https://github.com/dreemurrs-embedded/Pine64-Arch/blob/1f587391b4ac2e8d72c8b69cf2283a3310e14bb3/PKGBUILDS/pine64/danctnix-eg25-misc/eg25_power.sh
+
+# GPIO35 is PWRKEY
+# GPIO68 is RESET_N
+# GPIO232 is W_DISABLE
+
+for i in 35 68 232
+do
+    [ -e /sys/class/gpio/gpio$i ] && continue
+    echo $i > /sys/class/gpio/export || exit 1
+    echo out > /sys/class/gpio/gpio$i/direction || exit 1
+done
+
+echo 1 > /sys/class/gpio/gpio68/value
+echo 1 > /sys/class/gpio/gpio232/value
+
+echo 1 > /sys/class/gpio/gpio35/value && sleep 2 && echo 0 > /sys/class/gpio/gpio35/value
+
+if grep -q 1.1 /proc/device-tree/model
+then
+    # Intentional delay on Braveheart
+    # As modem gets corrupted very easily on that model.
+    sleep 30
+else
+    sleep 2
+fi
+
+echo 0 > /sys/class/gpio/gpio68/value || exit 1
+echo 0 > /sys/class/gpio/gpio232/value || exit 1
+
+( echo 1 > /sys/class/gpio/gpio35/value && sleep 2 && echo 0 > /sys/class/gpio/gpio35/value ) || exit 1
+
+sleep 2
+
+for i in 35 68 232
+do
+        [ ! -e /sys/class/gpio/gpio$i ] && continue
+        echo $i > /sys/class/gpio/unexport || exit 1
+done
+
+systemctl restart "${modem_manager[@]}" eg25-manager


### PR DESCRIPTION
When trying to understand the conditions that lead to the modem being restarted, I struggled a bit and had to reread the code several times.

As far as I understood, the modem gets restarted if:
1. the prefix directory does not exist, or
2. for none of the device names a full set of 4 symlinks can be found

Since the links for the modem cannot exist unless the prefix path exists too, the checks can be simplified, making them easier to read. If a full set of links is found, exit immediately, to make it clearer to new readers that the rest of the script is irrelevant for that case.

Also fix the quoting, so the `shellcheck disable`s can be removed again.