### PR TITLE
Fix biktorgj modem firmware generic check regression

### DIFF
--- a/eg25-autorestart/eg25-autorestart.sh
+++ b/eg25-autorestart/eg25-autorestart.sh
@@ -11,10 +11,10 @@ fi
 if [ -d "$prefix" ]; then
     for device in "${devices[@]}"; do
         for i in {0..3}; do
-            if [ -L "$prefix/""$device""$i""$suffix" ]; then
+            if [ -L "$prefix/"$device"$i""$suffix" ]; then
                 # Found a symlink, check if all links exist for this device
                 for j in {0..3}; do
-                    if [ ! -L "$prefix/""$device""$j""$suffix" ]; then
+                    if [ ! -L "$prefix/"$device"$j""$suffix" ]; then
                         break 2
                     fi
                 done


### PR DESCRIPTION
The latest patch (#6) made a regression on the generic check used to find biktorgj's firmware,this should fix it for everyone. @ght can you test it for me on your stock firmware?